### PR TITLE
Updates for v1.1.2 release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,15 @@
 History
 =======
 
+1.1.2 (2019-03-17)
+------------------
+* Brings this repo in sync with Paulo Herrera's old BitBucket and new GitHub
+* Adds some new examples and fixes some compatibility issues with != None
+* Vector image support for imagetoVTK
+* Adds more tests to CI
+* Adds "evtk" package (identical to "pyevtk") for backward compatibility with
+  depricated warning
+
 1.1.1 (2019-02-01)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def readme(fname):
 
 setup(
     name='pyevtk',
-    version='1.1.1',
+    version='1.1.2',
     description='Export data as binary VTK files',
     long_description=readme('README.md'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Just updates the change log and `setup.py` in preparation for a v1.1.2 release.

Since @paulo-herrera has made the associated release on [his repo](https://github.com/paulo-herrera/PyEVTK/releases/tag/v1.1.2), we should be good to go with a release here and then an update on pypi and conda-forge.