### PR TITLE
Enhancement: extending `pyevtk` to allow for usage of Parallel VTK files

### DIFF
--- a/examples/rectilinear.py
+++ b/examples/rectilinear.py
@@ -30,8 +30,12 @@
 # * This example shows how to export a rectilinear grid.       *
 # **************************************************************
 
-from pyevtk.hl import gridToVTK
+from pyevtk.hl import gridToVTK, writeParallelVTKGrid
 import numpy as np
+
+# ==================
+# Serial example
+# ==================
 
 # Dimensions
 nx, ny, nz = 6, 6, 2
@@ -57,4 +61,27 @@ gridToVTK(
     z,
     cellData={"pressure": pressure},
     pointData={"temp": temp},
+)
+
+
+# ==================
+# Parallel example
+# ==================
+
+# Dimensions
+x1 = np.linspace(0, 1, 10)
+x2 = np.linspace(1, 2, 20)
+
+y = np.linspace(0, 1, 10)
+z = np.linspace(0, 1, 10)
+
+gridToVTK("test.0", x1, y, z, start=(0, 0, 0))
+gridToVTK("test.1", x2, y, z, start=(9, 0, 0))
+
+writeParallelVTKGrid(
+    "test_full",
+    coordsData=((29, 10, 10), x.dtype),
+    starts=[(0, 0, 0), (9, 0, 0)],
+    ends=[(9, 9, 9), (28, 9, 9)],
+    sources=["test.0.vtr", "test.1.vtr"],
 )

--- a/pyevtk/hl.py
+++ b/pyevtk/hl.py
@@ -148,6 +148,7 @@ def imageToVTK(
 ):
     """
     Export data values as a rectangular image.
+
     Parameters
     ----------
     path : str
@@ -179,10 +180,12 @@ def imageToVTK(
     fieldData : dict, optional
         dictionary with variables associated with the field.
         Keys should be the names of the variable stored in each array.
+
     Returns
     -------
     str
         Full path to saved file.
+
     Notes
     -----
     At least, cellData or pointData must be present
@@ -225,7 +228,8 @@ def gridToVTK(
     path, x, y, z, start=(0, 0, 0), cellData=None, pointData=None, fieldData=None
 ):
     """
-    Write data values as a structured grid.
+    Write data values as a rectilinear or structured grid.
+
     Parameters
     ----------
     path : str

--- a/pyevtk/hl.py
+++ b/pyevtk/hl.py
@@ -108,7 +108,7 @@ def _addDataToParallelFile(vtkParallelFile, cellData, pointData):
         vectors = next((key for key in keys if cellData[key][1] == 3), None)
         vtkParallelFile.openData("PCell", scalars=scalars, vectors=vectors)
         for key in keys:
-            dtype, ncomp = pointData[key]
+            dtype, ncomp = cellData[key]
             vtkParallelFile.addHeader(key, dtype=dtype, ncomp=ncomp)
         vtkParallelFile.closeData("PCell")
 

--- a/pyevtk/hl.py
+++ b/pyevtk/hl.py
@@ -139,12 +139,12 @@ def _appendDataToFile(vtkFile, cellData, pointData, fieldData=None):
 # =================================
 def imageToVTK(
     path,
-    start=(0, 0, 0),
     origin=(0.0, 0.0, 0.0),
     spacing=(1.0, 1.0, 1.0),
     cellData=None,
     pointData=None,
     fieldData=None,
+    start=(0, 0, 0),
 ):
     """
     Export data values as a rectangular image.
@@ -225,7 +225,7 @@ def imageToVTK(
 
 # ==============================================================================
 def gridToVTK(
-    path, x, y, z, start=(0, 0, 0), cellData=None, pointData=None, fieldData=None
+    path, x, y, z, cellData=None, pointData=None, fieldData=None, start=(0, 0, 0)
 ):
     """
     Write data values as a rectilinear or structured grid.

--- a/pyevtk/hl.py
+++ b/pyevtk/hl.py
@@ -242,7 +242,7 @@ def gridToVTK(
         z coordinate axis.
     start : tuple, optional
         start of the coordinates.
-        Used in the distributed conwhere each process
+        Used in the distributed context where each process
         writes its own vtk file. Default is (0, 0, 0).
     cellData : dict, optional
         dictionary containing arrays with cell centered data.

--- a/pyevtk/vtk.py
+++ b/pyevtk/vtk.py
@@ -64,6 +64,29 @@ VtkStructuredGrid = VtkFileType("StructuredGrid", ".vts")
 VtkUnstructuredGrid = VtkFileType("UnstructuredGrid", ".vtu")
 
 
+class VtkParallelFileType:
+    """
+    A wrapper class for parallel vtk file types.
+
+    Parameters
+    ----------
+    vtkftype : VtkFileType
+        Vtk file type
+    """
+
+    def __init__(self, vtkftype):
+        self.name = "P" + vtkftype.name
+        ext = vtkftype.ext
+        self.ext = ext[0] + "p" + ext[1:]
+
+
+VtkPImageData = VtkParallelFileType(VtkImageData)
+VtkPPolyData = VtkParallelFileType(VtkPolyData)
+VtkPRectilinearGrid = VtkParallelFileType(VtkRectilinearGrid)
+VtkPStructuredGrid = VtkParallelFileType(VtkStructuredGrid)
+VtkPUnstructuredGrid = VtkParallelFileType(VtkUnstructuredGrid)
+
+
 #    DATA TYPES
 class VtkDataType:
     """
@@ -659,5 +682,239 @@ class VtkFile:
         """Close file."""
         if self.appendedDataIsOpen:
             self.xml.closeElement("AppendedData")
+        self.xml.closeElement("VTKFile")
+        self.xml.close()
+
+
+# ================================
+#        VtkParallelFile class
+# ================================
+class VtkParallelFile:
+    """
+    Class for a VTK parallel file.
+
+    Parameters
+    ----------
+    filepath : str
+        filename without extension
+    ftype : VtkParallelFileType
+    """
+
+    def __init__(self, filepath, ftype):
+        assert isinstance(ftype, VtkParallelFileType)
+        self.ftype = ftype
+        self.filename = filepath + ftype.ext
+        self.xml = XmlWriter(self.filename)
+        self.xml.openElement("VTKFile").addAttributes(
+            type=ftype.name,
+            version="1.0",
+            byte_order=_get_byte_order(),
+            header_type="UInt64",
+        )
+
+    def getFileName(self):
+        """Return absolute path to this file."""
+        return os.path.abspath(self.filename)
+
+    def addPiece(
+        self,
+        start=None,
+        end=None,
+        source=None,
+    ):
+        """
+        Add piece section with extent and source.
+        Parameters
+        ----------
+        start : array-like, optional
+            array or list with start indexes in each direction.
+            Must be given with end.
+        end : array-like, optional
+            array or list with end indexes in each direction.
+            Must be given with start.
+        source : str
+            Source of this piece
+        Returns
+        -------
+        VtkParallelFile
+            This VtkFile to allow chained calls.
+        """
+        # Check Source
+        assert source is not None
+        assert source.split(".")[-1] == self.ftype.ext[2:]
+
+        self.xml.openElement("Piece")
+        if start and end:
+            ext = _mix_extents(start, end)
+            self.xml.addAttributes(Extent=ext)
+        self.xml.addAttributes(Source=source)
+        self.xml.closeElement()
+        return self
+
+    def openData(
+        self,
+        nodeType,
+        scalars=None,
+        vectors=None,
+        normals=None,
+        tensors=None,
+        tcoords=None,
+    ):
+        """
+        Open data section.
+        Parameters
+        ----------
+        nodeType : str
+            Either "Point", "Cell" or "Field".
+        scalars : str, optional
+            default data array name for scalar data.
+        vectors : str, optional
+            default data array name for vector data.
+        normals : str, optional
+            default data array name for normals data.
+        tensors : str, optional
+            default data array name for tensors data.
+        tcoords : str, optional
+            default data array name for tcoords data.
+        Returns
+        -------
+        VtkFile
+            This VtkFile to allow chained calls.
+        """
+        self.xml.openElement(nodeType + "Data")
+        if scalars:
+            self.xml.addAttributes(Scalars=scalars)
+        if vectors:
+            self.xml.addAttributes(Vectors=vectors)
+        if normals:
+            self.xml.addAttributes(Normals=normals)
+        if tensors:
+            self.xml.addAttributes(Tensors=tensors)
+        if tcoords:
+            self.xml.addAttributes(TCoords=tcoords)
+
+        return self
+
+    def closeData(self, nodeType):
+        """
+        Close data section.
+        Parameters
+        ----------
+        nodeType : str
+            "Point", "Cell" or "Field".
+        Returns
+        -------
+        VtkFile
+            This VtkFile to allow chained calls.
+        """
+        self.xml.closeElement(nodeType + "Data")
+
+    def openGrid(self, start=None, end=None, origin=None, spacing=None, ghostlevel=0):
+        """
+        Open grid section.
+
+        Parameters
+        ----------
+        start : array-like, optional
+            array or list of start indexes.
+            Required for Structured, Rectilinear and ImageData grids.
+            The default is None.
+        end : array-like, optional
+            array or list of end indexes.
+            Required for Structured, Rectilinear and ImageData grids.
+            The default is None.
+        origin : array-like, optional
+            3D array or list with grid origin.
+            Only required for ImageData grids.
+            The default is None.
+        spacing : array-like, optional
+            3D array or list with grid spacing.
+            Only required for ImageData grids.
+            The default is None.
+        ghostlevel : int
+            Number of ghost-levels by which
+            the extents in the individual pieces overlap.
+        Returns
+        -------
+        VtkFile
+            This VtkFile to allow chained calls.
+        """
+        gType = self.ftype.name
+        self.xml.openElement(gType)
+
+        if gType == VtkPImageData.name:
+            if not start or not end or not origin or not spacing:
+                raise ValueError(f"start, end, origin and spacing required for {gType}")
+            ext = _mix_extents(start, end)
+            self.xml.addAttributes(
+                WholeExtent=ext,
+                Origin=_array_to_string(origin),
+                Spacing=_array_to_string(spacing),
+            )
+
+        elif gType in [VtkPStructuredGrid.name, VtkPRectilinearGrid.name]:
+            if not start or not end:
+                raise ValueError(f"start and end required for {gType}.")
+            ext = _mix_extents(start, end)
+            self.xml.addAttributes(WholeExtent=ext)
+
+        # Ghostlevel
+        self.xml.addAttributes(Ghostlevel=ghostlevel)
+        return self
+
+    def closeGrid(self):
+        """
+        Close grid element.
+        Returns
+        -------
+        VtkFile
+            This VtkFile to allow chained calls.
+        """
+        self.xml.closeElement(self.ftype.name)
+
+    def addHeader(self, name, dtype, ncomp):
+        """
+        Add data array description to xml header section.
+        Parameters
+        ----------
+        name : str
+            data array name.
+        dtype : str
+            data type.
+        ncomp : int
+            number of components, 1 (=scalar) and 3 (=vector).
+        Returns
+        -------
+
+        VtkFile
+            This VtkFile to allow chained calls.
+        Notes
+        -----
+
+        This is a low level function.
+        Use addData if you want to add a numpy array.
+        """
+        dtype = np_to_vtk[dtype.name]
+
+        self.xml.openElement("DataArray")
+        self.xml.addAttributes(
+            Name=name,
+            NumberOfComponents=ncomp,
+            type=dtype.name,
+        )
+        self.xml.closeElement()
+
+    def openElement(self, tagName):
+        """
+        Open an element.
+        Useful to add elements such as: Coordinates, Points, Verts, etc.
+        """
+        self.xml.openElement(tagName)
+
+    def closeElement(self, tagName):
+        self.xml.closeElement(tagName)
+
+    def save(self):
+        """Close file."""
         self.xml.closeElement("VTKFile")
         self.xml.close()


### PR DESCRIPTION
Hello, I have been using `pyevtk` to write VTK files without having the VTK library as a dependency and I have been very happy with it. The only thing it was missing in my use case was the ability to write "parallel VTK files" as described on the [Kitware website](https://kitware.github.io/vtk-examples/site/VTKFileFormats/#parallel-file-formats).

This pull request consists of :
* A simple reformat of `examples/image.py`, `pyevtk/__init__.py`, `pyevtk/_version.py`, `setup.py`, `test/dummy.py`, `versionner.py` and `pyevtk/evtk.py`.
* The addition of two classes `VtkParallelFileType` and `VtkParallel` which are heavily borrowed from their serial counterpart but changed to be taylored for parallel VTK files.
* Turning start into a keyword argument in some high-level functions
* Adding a new high-level function to write a parallelVTK file for one of the two grids format. 