### PR TITLE
imageToVTK: determine low-dim grid from spacing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     env:
       SDIST_DIR: /tmp/sdist

--- a/pyevtk/hl.py
+++ b/pyevtk/hl.py
@@ -205,7 +205,7 @@ def imageToVTK(
         for i, s in enumerate(spacing):
             if np.isclose(s, 0.0):
                 if end[i] == 1:
-                    end = end[:i] + (0,) + end[i+1:]
+                    end = end[:i] + (0,) + end[i + 1 :]
                 else:
                     raise ValueError("imageToVTK: grid has lower dimension than data")
     elif pointData is not None:

--- a/pyevtk/hl.py
+++ b/pyevtk/hl.py
@@ -202,6 +202,12 @@ def imageToVTK(
             end = data.shape
         elif data[0].ndim == 3 and data[1].ndim == 3 and data[2].ndim == 3:
             end = data[0].shape
+        for i, s in enumerate(spacing):
+            if np.isclose(s, 0.0):
+                if end[i] == 1:
+                    end = end[:i] + (0,) + end[i+1:]
+                else:
+                    raise ValueError("imageToVTK: grid has lower dimension than data")
     elif pointData is not None:
         keys = list(pointData.keys())
         data = pointData[keys[0]]
@@ -210,6 +216,9 @@ def imageToVTK(
         elif data[0].ndim == 3 and data[1].ndim == 3 and data[2].ndim == 3:
             end = data[0].shape
         end = (end[0] - 1, end[1] - 1, end[2] - 1)
+        for i, s in enumerate(spacing):
+            if np.isclose(s, 0.0) and end[i] > 0:
+                raise ValueError("imageToVTK: grid has lower dimension than data")
 
     # Write data to file
     w = VtkFile(path, VtkImageData)

--- a/pyevtk/vtk.py
+++ b/pyevtk/vtk.py
@@ -36,6 +36,7 @@ from .xml import XmlWriter
 #            VTK Types
 # ================================
 
+
 #     FILE TYPES
 class VtkFileType:
     """

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,10 @@ setup(
     setup_requires=["pytest-runner"],
     tests_require=["pytest>=3.1", "pytest-cov", "twine", "check-manifest"],
     classifiers=[
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )


### PR DESCRIPTION
Closes #37 

imageToVTK was not able to determine lower dimension grids from given cell-data. Meaning: if cell data had a single slice in one direction, imageToVTK assumed it always to be 3D. But from given spacing of `0.0` one could determine that the cell elements should be 2D (or even 1D).

This PR fixes this issue and adds checks for spacing and data shapes.