### PR TITLE
Add license info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     author_email="pauloa.herrera@gmail.com",
     maintainer="Adamos Kyriakou",
     maintainer_email="somada141@gmail.com",
+    license="BSD-2-Clause",
     url="https://github.com/pyscience-projects/pyevtk",
     packages=["pyevtk", "evtk"],
     package_dir={"pyevtk": "pyevtk"},


### PR DESCRIPTION
Fixes license specifiers according to https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

This allows automatic license inspection tools like pip-licenses to correctly categorize this package.