### PR TITLE
Update license file and headers to match upstream

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Paulo A. Herrera
+Copyright (c) 2021-2024 Paulo A. Herrera
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,24 +1,21 @@
-***********************************************************************************
-* Copyright 2010 - 2016 Paulo A. Herrera. All rights reserved.                    *
-*                                                                                 *
-* Redistribution and use in source and binary forms, with or without              *
-* modification, are permitted provided that the following conditions are met:     *
-*                                                                                 *
-*  1. Redistributions of source code must retain the above copyright notice,      *
-*  this list of conditions and the following disclaimer.                          *
-*                                                                                 *
-*  2. Redistributions in binary form must reproduce the above copyright notice,   *
-*  this list of conditions and the following disclaimer in the documentation      *
-*  and/or other materials provided with the distribution.                         *
-*                                                                                 *
-* THIS SOFTWARE IS PROVIDED BY PAULO A. HERRERA ``AS IS'' AND ANY EXPRESS OR      *
-* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    *
-* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO      *
-* EVENT SHALL <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,        *
-* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,  *
-* BUT NOT LIMITED TO, PROCUREMEN OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,    *
-* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           *
-* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING  *
-* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS              *
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                    *
-***********************************************************************************
+MIT License
+
+Copyright (c) 2021 Paulo A. Herrera
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyevtk/__init__.py
+++ b/pyevtk/__init__.py
@@ -1,21 +1,26 @@
-# *************************************************************************
-# * Copyright 2010 - 2016 Paulo Herrera                                   *
-# *                                                                       *
-# * This file is part of EVTK.                                            *
-# *                                                                       *
-# * EVTK is free software: you can redistribute it and/or modify          *
-# * it under the terms of the GNU General Public License as published by  *
-# * the Free Software Foundation, either version 3 of the License, or     *
-# * (at your option) any later version.                                   *
-# *                                                                       *
-# * EVTK is distributed in the hope that it will be useful,               *
-# * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# * GNU General Public License for more details.                          *
-# *                                                                       *
-# * You should have received a copy of the GNU General Public License     *
-# * along with EVTK.  If not, see <http://www.gnu.org/licenses/>.         *
-# *************************************************************************
+######################################################################################
+# MIT License
+#
+# Copyright (c) 2010-2021 Paulo A. Herrera
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+######################################################################################
 
 from . import evtk
 from . import hl

--- a/pyevtk/__init__.py
+++ b/pyevtk/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################################
 # MIT License
 #
-# Copyright (c) 2010-2021 Paulo A. Herrera
+# Copyright (c) 2010-2024 Paulo A. Herrera
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyevtk/evtk.py
+++ b/pyevtk/evtk.py
@@ -1,27 +1,26 @@
-﻿# ***********************************************************************************
-# * Copyright 2010 - 2016 Paulo A. Herrera. All rights reserved.                    *
-# *                                                                                 *
-# * Redistribution and use in source and binary forms, with or without              *
-# * modification, are permitted provided that the following conditions are met:     *
-# *                                                                                 *
-# *  1. Redistributions of source code must retain the above copyright notice,      *
-# *  this list of conditions and the following disclaimer.                          *
-# *                                                                                 *
-# *  2. Redistributions in binary form must reproduce the above copyright notice,   *
-# *  this list of conditions and the following disclaimer in the documentation      *
-# *  and/or other materials provided with the distribution.                         *
-# *                                                                                 *
-# * THIS SOFTWARE IS PROVIDED BY PAULO A. HERRERA ``AS IS'' AND ANY EXPRESS OR      *
-# * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    *
-# * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO      *
-# * EVENT SHALL <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,        *
-# * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,  *
-# * BUT NOT LIMITED TO, PROCUREMEN OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,    *
-# * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           *
-# * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING  *
-# * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS              *
-# * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                    *
-# ***********************************************************************************
+﻿######################################################################################
+# MIT License
+#
+# Copyright (c) 2010-2021 Paulo A. Herrera
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+######################################################################################
 """Export routines."""
 
 import sys

--- a/pyevtk/evtk.py
+++ b/pyevtk/evtk.py
@@ -1,7 +1,7 @@
 ﻿######################################################################################
 # MIT License
 #
-# Copyright (c) 2010-2021 Paulo A. Herrera
+# Copyright (c) 2010-2024 Paulo A. Herrera
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyevtk/hl.py
+++ b/pyevtk/hl.py
@@ -1,27 +1,26 @@
-# ***********************************************************************************
-# * Copyright 2010 - 2016 Paulo A. Herrera. All rights reserved.                    *
-# *                                                                                 *
-# * Redistribution and use in source and binary forms, with or without              *
-# * modification, are permitted provided that the following conditions are met:     *
-# *                                                                                 *
-# *  1. Redistributions of source code must retain the above copyright notice,      *
-# *  this list of conditions and the following disclaimer.                          *
-# *                                                                                 *
-# *  2. Redistributions in binary form must reproduce the above copyright notice,   *
-# *  this list of conditions and the following disclaimer in the documentation      *
-# *  and/or other materials provided with the distribution.                         *
-# *                                                                                 *
-# * THIS SOFTWARE IS PROVIDED BY PAULO A. HERRERA ``AS IS'' AND ANY EXPRESS OR      *
-# * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    *
-# * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO      *
-# * EVENT SHALL <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,        *
-# * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,  *
-# * BUT NOT LIMITED TO, PROCUREMEN OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,    *
-# * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           *
-# * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING  *
-# * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS              *
-# * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                    *
-# ***********************************************************************************
+######################################################################################
+# MIT License
+#
+# Copyright (c) 2010-2021 Paulo A. Herrera
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+######################################################################################
 """High level Python library to export data to binary VTK file."""
 
 import numpy as np

--- a/pyevtk/hl.py
+++ b/pyevtk/hl.py
@@ -1,7 +1,7 @@
 ######################################################################################
 # MIT License
 #
-# Copyright (c) 2010-2021 Paulo A. Herrera
+# Copyright (c) 2010-2024 Paulo A. Herrera
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyevtk/vtk.py
+++ b/pyevtk/vtk.py
@@ -1,27 +1,26 @@
-# ***********************************************************************************
-# * Copyright 2010 - 2016 Paulo A. Herrera. All rights reserved.                    *
-# *                                                                                 *
-# * Redistribution and use in source and binary forms, with or without              *
-# * modification, are permitted provided that the following conditions are met:     *
-# *                                                                                 *
-# *  1. Redistributions of source code must retain the above copyright notice,      *
-# *  this list of conditions and the following disclaimer.                          *
-# *                                                                                 *
-# *  2. Redistributions in binary form must reproduce the above copyright notice,   *
-# *  this list of conditions and the following disclaimer in the documentation      *
-# *  and/or other materials provided with the distribution.                         *
-# *                                                                                 *
-# * THIS SOFTWARE IS PROVIDED BY PAULO A. HERRERA ``AS IS'' AND ANY EXPRESS OR      *
-# * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    *
-# * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO      *
-# * EVENT SHALL <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,        *
-# * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,  *
-# * BUT NOT LIMITED TO, PROCUREMEN OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,    *
-# * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           *
-# * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING  *
-# * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS              *
-# * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                    *
-# ***********************************************************************************
+######################################################################################
+# MIT License
+#
+# Copyright (c) 2010-2021 Paulo A. Herrera
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+######################################################################################
 """Low level Python library to export data to binary VTK file."""
 
 import sys

--- a/pyevtk/vtk.py
+++ b/pyevtk/vtk.py
@@ -1,7 +1,7 @@
 ######################################################################################
 # MIT License
 #
-# Copyright (c) 2010-2021 Paulo A. Herrera
+# Copyright (c) 2010-2024 Paulo A. Herrera
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyevtk/xml.py
+++ b/pyevtk/xml.py
@@ -1,27 +1,26 @@
-# ***********************************************************************************
-# * Copyright 2010 - 2016 Paulo A. Herrera. All rights reserved                     *
-# *                                                                                 *
-# * Redistribution and use in source and binary forms, with or without              *
-# * modification, are permitted provided that the following conditions are met:     *
-# *                                                                                 *
-# *  1. Redistributions of source code must retain the above copyright notice,      *
-# *  this list of conditions and the following disclaimer.                          *
-# *                                                                                 *
-# *  2. Redistributions in binary form must reproduce the above copyright notice,   *
-# *  this list of conditions and the following disclaimer in the documentation      *
-# *  and/or other materials provided with the distribution.                         *
-# *                                                                                 *
-# * THIS SOFTWARE IS PROVIDED BY PAULO A. HERRERA ``AS IS'' AND ANY EXPRESS OR      *
-# * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    *
-# * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO      *
-# * EVENT SHALL <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,        *
-# * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,  *
-# * BUT NOT LIMITED TO, PROCUREMEN OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,    *
-# * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           *
-# * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING  *
-# * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS              *
-# * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                    *
-# ***********************************************************************************
+######################################################################################
+# MIT License
+#
+# Copyright (c) 2010-2021 Paulo A. Herrera
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+######################################################################################
 """Simple class to generate a well-formed XML file."""
 
 

--- a/pyevtk/xml.py
+++ b/pyevtk/xml.py
@@ -1,7 +1,7 @@
 ######################################################################################
 # MIT License
 #
-# Copyright (c) 2010-2021 Paulo A. Herrera
+# Copyright (c) 2010-2024 Paulo A. Herrera
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,26 @@
-# ***********************************************************************************
-# * Copyright 2010-2017 Paulo A. Herrera. All rights reserved.                           *
-# *                                                                                 *
-# * Redistribution and use in source and binary forms, with or without              *
-# * modification, are permitted provided that the following conditions are met:     *
-# *                                                                                 *
-# *  1. Redistributions of source code must retain the above copyright notice,      *
-# *  this list of conditions and the following disclaimer.                          *
-# *                                                                                 *
-# *  2. Redistributions in binary form must reproduce the above copyright notice,   *
-# *  this list of conditions and the following disclaimer in the documentation      *
-# *  and/or other materials provided with the distribution.                         *
-# *                                                                                 *
-# * THIS SOFTWARE IS PROVIDED BY PAULO A. HERRERA ``AS IS'' AND ANY EXPRESS OR      *
-# * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF    *
-# * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO      *
-# * EVENT SHALL <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,        *
-# * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,  *
-# * BUT NOT LIMITED TO, PROCUREMEN OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,    *
-# * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           *
-# * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING  *
-# * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS              *
-# * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                    *
-# ***********************************************************************************
+######################################################################################
+# MIT License
+#
+# Copyright (c) 2010-2024 Paulo A. Herrera
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+######################################################################################
 
 try:
     from setuptools import setup
@@ -48,7 +47,7 @@ setup(
     author_email="pauloa.herrera@gmail.com",
     maintainer="Adamos Kyriakou",
     maintainer_email="somada141@gmail.com",
-    license="BSD-2-Clause",
+    license="MIT",
     url="https://github.com/pyscience-projects/pyevtk",
     packages=["pyevtk", "evtk"],
     package_dir={"pyevtk": "pyevtk"},


### PR DESCRIPTION
I tried to keep the commit messages the same as on https://github.com/paulo-herrera/PyEVTK but it wasn't easy to truly cherry-pick them.

I also updated `setup.py` to be consistent.